### PR TITLE
context.nest instead of context.fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ import {
   query,
   match,
   transient,
-  fork
+  nest
 } from 'ember-zeug/model/computed';
 ```
 
@@ -44,7 +44,7 @@ export default Context.extend({
 
   identity,
 
-  fork,
+  nest,
   model,
   existing,
   query,
@@ -239,9 +239,9 @@ export default Component.extend({
 });
 ```
 
-### Fork
+### Nest
 
-Forks a nested context which is destroyed when owner is.
+Create a nested context which is destroyed when owner is.
 
 ``` javascript
 export default Component.extend({
@@ -250,7 +250,7 @@ export default Component.extend({
 
   name: 'hey',
 
-  forked: fork(function() {
+  nested: nest(function() {
     let name = this.get('name');
     return {
       context: 'context',

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 # TODO
 
-* rename `context.fork()` to `context.nest()` and computed helper `fork` to `nest`
 * figure out api for session and storage so that I have a better understanding regarding exports
 * transforms for attr
 * tests for query computed

--- a/app/components/ui-route/crud/component.js
+++ b/app/components/ui-route/crud/component.js
@@ -1,10 +1,10 @@
 import Component from '@ember/component';
-import { transient, fork } from 'models/model/computed';
+import { transient, nest } from 'models/model/computed';
 
 export default Component.extend({
   classNameBindings: [ ':ui-route-crud' ],
 
-  context: fork({
+  context: nest({
     context: 'store',
     name: 'crud'
   }),

--- a/app/components/ui-route/crud/detail/edit/component.js
+++ b/app/components/ui-route/crud/detail/edit/component.js
@@ -1,11 +1,11 @@
 import Component from '../base/component';
-import { fork, transient } from 'models/model/computed';
+import { nest, transient } from 'models/model/computed';
 
 export default Component.extend({
 
   componentNamePrefix: 'edit',
 
-  context: fork({
+  context: nest({
     context: 'model.context',
     name: 'edit'
   }),

--- a/app/components/ui-route/people/person/edit/template.hbs
+++ b/app/components/ui-route/people/person/edit/template.hbs
@@ -41,7 +41,7 @@
 
   {{#rows.row}}
     <div class="identity">
-      Note: this document edit is being run in forked context which is discarded on route transition so we get rollback for free.
+      Note: this document edit is being run in nested context which is discarded on route transition so we get rollback for free.
     </div>
   {{/rows.row}}
 

--- a/app/mixins/route/nest.js
+++ b/app/mixins/route/nest.js
@@ -5,9 +5,9 @@ export default Mixin.create(DestroyContext, {
 
   context: null,
 
-  fork(name) {
+  nest(name) {
     name = name || this.get('context');
-    return this.get('store').fork(name);
+    return this.get('store').nest(name);
   }
 
 });

--- a/app/routes/match.js
+++ b/app/routes/match.js
@@ -3,7 +3,7 @@ import Route from '@ember/routing/route';
 export default Route.extend({
 
   model() {
-    return this.get('store').fork('match');
+    return this.get('store').nest('match');
   },
 
   deactivate() {

--- a/app/routes/model.js
+++ b/app/routes/model.js
@@ -4,7 +4,7 @@ export default Route.extend({
 
   model(props) {
     let { path } = props;
-    return this.get('store').fork('document').first({ path, optional: true });
+    return this.get('store').nest('document').first({ path, optional: true });
   },
 
   deactivate() {

--- a/app/routes/people/person/edit.js
+++ b/app/routes/people/person/edit.js
@@ -1,13 +1,13 @@
 import Route from '@ember/routing/route';
-import ForkMixin from 'thing/mixins/route/fork';
+import NestMixin from 'thing/mixins/route/nest';
 
-export default Route.extend(ForkMixin, {
+export default Route.extend(NestMixin, {
 
   context: 'person-edit',
 
   model() {
     let id = this.modelFor('people.person').get('id');
-    let model = this.fork().model({ name: 'person/edit', data: { id } });
+    let model = this.nest().model({ name: 'person/edit', data: { id } });
     return model.load();
   }
 

--- a/app/routes/queries.js
+++ b/app/routes/queries.js
@@ -3,7 +3,7 @@ import Route from '@ember/routing/route';
 export default Route.extend({
 
   model() {
-    return this.get('store').fork('queries');
+    return this.get('store').nest('queries');
   },
 
   deactivate() {

--- a/lib/models/addon/-private/computed/global/index.js
+++ b/lib/models/addon/-private/computed/global/index.js
@@ -3,9 +3,9 @@ import property from '../make-property';
 import QueryProperty from './query';
 import MatchProperty from './match';
 import TransientProperty from './transient';
-import ForkProperty from './fork';
+import NestProperty from './nest';
 
 export const query = property(QueryProperty);
 export const match = property(MatchProperty);
 export const transient = property(TransientProperty);
-export const fork = property(ForkProperty);
+export const nest = property(NestProperty);

--- a/lib/models/addon/-private/computed/global/nest.js
+++ b/lib/models/addon/-private/computed/global/nest.js
@@ -1,10 +1,10 @@
 import Property from '../property';
 
-export default class ForkProperty extends Property {
+export default class NestProperty extends Property {
 
   createInternalModel() {
     let name = this.opts.name;
-    return this.context.fork(name);
+    return this.context.nest(name);
   }
 
   getValue() {

--- a/lib/models/addon/-private/context/context.js
+++ b/lib/models/addon/-private/context/context.js
@@ -14,7 +14,7 @@ export default EmberObject.extend(InternalMixin, {
   identity: identity(),
 
   // identifier
-  fork: model('fork'),
+  nest: model('nest'),
 
   // { name, id, collection, path, data: { ... } }
   model: model('build'),

--- a/lib/models/addon/-private/context/internal-context.js
+++ b/lib/models/addon/-private/context/internal-context.js
@@ -69,7 +69,7 @@ export default class InternalContext extends Internal {
     return this.factoryFor(factoryName).create({ _internal: this });
   }
 
-  fork(identifier) {
+  nest(identifier) {
     let internal = this.stores.createInternalNestedContext(this, identifier);
     this.contexts.pushObject(internal);
     return internal;

--- a/tests/unit/matcher-test.js
+++ b/tests/unit/matcher-test.js
@@ -42,7 +42,7 @@ test('create single', async function(assert) {
 });
 
 test('destroy context', async function(assert) {
-  let context = this.store.fork('foof');
+  let context = this.store.nest('foof');
   let model = context.matcher({ type: 'single', matches: () => true });
   let internal = model._internal;
 


### PR DESCRIPTION
It is not a clone of parent context, so `nest` is more appropriate.